### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository.
-      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     timeout-minutes: 40
 
     strategy:

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -12,10 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: Run Cypress Test Matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository.
+      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     timeout-minutes: 40
 
     strategy:

--- a/.github/workflows/cypress-tests-beta.yml
+++ b/.github/workflows/cypress-tests-beta.yml
@@ -10,10 +10,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: Run Cypress Beta Only Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository.
+      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cypress-tests-beta.yml
+++ b/.github/workflows/cypress-tests-beta.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository.
-      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,7 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository.
-      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     timeout-minutes: 60
     steps:
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,10 +21,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: Run Cypress Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository.
+      actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
     steps:
 
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,6 +32,7 @@ jobs:
     permissions:
       contents: read       # Required to clone the private repository.
       actions: write       # Required for actions/cache and for conditional actions/upload-artifact uploads.
+    timeout-minutes: 60
     steps:
 
       - name: Checkout

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -5,10 +5,15 @@ on:
     types:
       - deleted
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   delete:
     name: On Delete Release
     runs-on: ubuntu-latest
+    permissions: {} # Steps only purge Cloudflare cache; no GITHUB_TOKEN GitHub API usage.
     if: ${{ github.repository == 'newfold-labs/wp-plugin-blueprint' }}
     steps:
 

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {} # Steps only purge Cloudflare cache; no GITHUB_TOKEN GitHub API usage.
     if: ${{ github.repository == 'newfold-labs/wp-plugin-blueprint' }}
+    timeout-minutes: 10
     steps:
 
       - name: Clear cache for release API

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository and for get-diff-action.
-      actions: write       # Required for actions/cache to save and restore the Composer cache.
     timeout-minutes: 30
     steps:
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository and for get-diff-action.
+      actions: write       # Required for actions/cache to save and restore the Composer cache.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read       # Required to clone the private repository and for get-diff-action.
       actions: write       # Required for actions/cache to save and restore the Composer cache.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -10,9 +10,16 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-yml:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository.
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # repository-dispatch uses WEBHOOK_TOKEN; GITHUB_TOKEN not used for GitHub API calls.
+    timeout-minutes: 10
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # repository-dispatch uses WEBHOOK_TOKEN; GITHUB_TOKEN not used for GitHub API calls.
     steps:
 
       - name: Set Package

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # Required to clone the private repository.
-      actions: write       # Required for actions/cache and for actions/upload-artifact.
     timeout-minutes: 45
     steps:
 

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -16,10 +16,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Push
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the private repository.
+      actions: write       # Required for actions/cache and for actions/upload-artifact.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-artifact-on-push.yml
+++ b/.github/workflows/upload-artifact-on-push.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read       # Required to clone the private repository.
       actions: write       # Required for actions/cache and for actions/upload-artifact.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the repo and upload the release zip with actions/upload-release-asset.
       actions: write       # Required for actions/cache to save and restore npm and Composer caches.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -12,10 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     name: On Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to clone the repo and upload the release zip with actions/upload-release-asset.
+      actions: write       # Required for actions/cache to save and restore npm and Composer caches.
     steps:
 
       - name: Checkout

--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write      # Required to clone the repo and upload the release zip with actions/upload-release-asset.
-      actions: write       # Required for actions/cache to save and restore npm and Composer caches.
     timeout-minutes: 45
     steps:
 

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -8,9 +8,17 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   wp-i18n:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to clone the repo and push i18n updates via github-push-action.
+      actions: write       # Required for actions/cache to save and restore the Composer cache.
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write      # Required to clone the repo and push i18n updates via github-push-action.
-      actions: write       # Required for actions/cache to save and restore the Composer cache.
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/.github/workflows/wp-i18n.yml
+++ b/.github/workflows/wp-i18n.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write      # Required to clone the repo and push i18n updates via github-push-action.
       actions: write       # Required for actions/cache to save and restore the Composer cache.
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 10 (`cypress-matrix.yml`, `cypress-tests-beta.yml`, `cypress.yml`, `delete-release.yml`, `lint-php.yml`, `lint-yml.yml`, `satis-webhook.yml`, `upload-artifact-on-push.yml`, `upload-asset-on-release.yml`, `wp-i18n.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `e71f9eb` |
| Timeouts commit | `ae4b46a` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `cypress-matrix.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `cypress-tests-beta.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `cypress.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `delete-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-yml.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-artifact-on-push.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `upload-asset-on-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `wp-i18n.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| cypress-matrix.yml | 1 job was missing a scoped `permissions:` directive | test | `contents: read`, `actions: write` [3] |
| cypress-tests-beta.yml | 1 job was missing a scoped `permissions:` directive | test | `contents: read`, `actions: write` [3] |
| cypress.yml | 1 job was missing a scoped `permissions:` directive | test | `contents: read`, `actions: write` [3] |
| delete-release.yml | 1 job was missing a scoped `permissions:` directive | delete | `{}` [3] |
| lint-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `actions: write` [3] |
| lint-yml.yml | 1 job was missing a scoped `permissions:` directive | lint-yml | `contents: read` [3] |
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `{}` [3] |
| upload-artifact-on-push.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: read`, `actions: write` [3] |
| upload-asset-on-release.yml | 1 job was missing a scoped `permissions:` directive | build | `contents: write`, `actions: write` [3] |
| wp-i18n.yml | 1 job was missing a scoped `permissions:` directive | wp-i18n | `contents: write`, `actions: write` [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| wp-i18n.yml | wp-i18n | `30` | POT generation and Composer/Node setup are usually quick; 30 minutes is a safe ceiling without starving slower runners. |
| upload-asset-on-release.yml | build | `45` | Release packaging runs Composer, npm install/build, rsync, zip, and a release asset upload; 45 minutes allows for dependency and build variance. |
| upload-artifact-on-push.yml | build | `45` | Push artifact builds mirror most of the release build path minus the GitHub release upload; 45 minutes matches expected npm/Composer/build cost. |
| satis-webhook.yml | webhook | `10` | The job only computes strings and fires repository dispatch; 10 minutes is ample headroom for API latency. |
| lint-yml.yml | lint-yml | `15` | Checkout plus yamllint across workflow files should complete well under 15 minutes. |
| lint-php.yml | phpcs | `30` | Composer install and PHPCS on a diff set are typically short; 30 minutes covers cold-cache Composer fetches. |
| delete-release.yml | delete | `10` | Single Cloudflare cache purge request; 10 minutes is more than sufficient. |
| cypress.yml | test | `60` | `wp-env start` plus Cypress (including optional Cypress Cloud recording) is the longest path; 60 minutes reduces risk of false timeouts on cold starts. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Scoped job tokens now rely on `actions: write` where `actions/cache`, `actions/upload-artifact`, or both appear, consistent with GitHub’s cache/artifact permission model; if GitHub introduces finer-grained splits later, these jobs could be re-tightened. |
| 2 | `peter-evans/repository-dispatch@v3` was verified to use the configured `WEBHOOK_TOKEN` PAT for cross-repo dispatch, so the job correctly uses `permissions: {}` for `GITHUB_TOKEN`. |
| 3 | `cypress-tests-beta.yml` and `cypress-matrix.yml` already had `timeout-minutes` and those values were not changed. |


